### PR TITLE
fix missing packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,15 @@
   "dependencies": {
     "MD5": "^1.2.1",
     "body-parser": "^1.5.0",
+    "browserify": "^11.2.0",
     "connect-auth": "^0.6.1",
     "cookie-parser": "^1.3.4",
     "express-session": "^1.10.3",
     "extend": "^3.0.0",
-    "hexo-fs": "^0.1.3",
     "hexo-front-matter": "^0.2.2",
+    "hexo-fs": "^0.1.3",
     "hexo-util": "^0.1.6",
+    "less": "^2.5.1",
     "moment": "^2.7.0",
     "serve-static": "^1.4.0"
   },


### PR DESCRIPTION
When I was doing npm install, it came with an error.
```
> make build less

/bin/sh: browserify: command not found
make: *** [build] Error 127

npm ERR! Darwin 13.4.0
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.12.7
npm ERR! npm  v3.3.3
npm ERR! code ELIFECYCLE
npm ERR! hexo-admin@1.1.0 prepublish: `make build less`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the hexo-admin@1.1.0 prepublish script 'make build less'.
npm ERR! This is most likely a problem with the hexo-admin package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     make build less
npm ERR! You can get their info via:
npm ERR!     npm owner ls hexo-admin
npm ERR! There is likely additional logging output above.
```
I found it was caused by missing two packages, which are browserify and less