### PR TITLE
Added support for a different hexo.config.root

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,29 +1,35 @@
 var serveStatic = require('serve-static'),
-	bodyParser = require('body-parser'),
-	path = require('path'),
-	api = require('./api'),
-	passwordProtected = hexo.config.admin && hexo.config.admin.username;
+  bodyParser = require('body-parser'),
+  path = require('path'),
+  api = require('./api');
+
+var passwordProtected = hexo.config.admin && hexo.config.admin.username;
 
 // verify that correct config options are set.
 if (passwordProtected) {
-    if (!hexo.config.admin.password_hash) {
-        console.error('[Hexo Admin]: config admin.password_hash is requred for authentication')
-        passwordProtected = false
-    }
-    if (!hexo.config.admin.secret) {
-        console.error('[Hexo Admin]: config admin.secret is requred for authentication')
-        passwordProtected = false
-    }
+  if (!hexo.config.admin.password_hash) {
+    console.error('[Hexo Admin]: config admin.password_hash is requred for authentication');
+    passwordProtected = false;
+  }
+  
+  if (!hexo.config.admin.secret) {
+    console.error('[Hexo Admin]: config admin.secret is requred for authentication');
+    passwordProtected = false;
+  }
 }
 
-hexo.extend.filter.register('server_middleware', function (app) {
+hexo.extend.filter.register('server_middleware', function(app) {
 
   if (passwordProtected) {
-    // setup authentication, login page, etc.
-    require('./auth')(app, hexo)
+    require('./auth')(app, hexo);   // setup authentication, login page, etc.
   }
-  app.use('/admin/', serveStatic(path.join(__dirname, 'www')));
-  app.use('/admin/api/', bodyParser.json({limit: '50mb'}))
+
+  var rootPath = hexo.config.root + (hexo.config.root.substr(hexo.config.root.length - 1) == '/' ? '' : '/');
+
+  // Main routes
+  app.use(hexo.config.root + 'admin/', serveStatic(path.join(__dirname, 'www')));
+  app.use(hexo.config.root + 'admin/api/', bodyParser.json({limit: '50mb'}))
+
   // setup the json api endpoints
   api(app, hexo);
 });


### PR DESCRIPTION
Given the option that Hexo has to allow serving the blog from a different root, added support to hexo-admin to work with that option.

PS: I have some styling questions, are you following any code styling guide like Airbnb's or there is nothing defined here yet?