### PR TITLE
Fix auth paths

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,5 +1,7 @@
 var path = require('path')
 var fs = require('fs')
+var urljoin = require('url-join');
+
 var updateAny = require('./update')
   , updatePage = updateAny.bind(null, 'Page')
   , update = updateAny.bind(null, 'Post')
@@ -65,7 +67,7 @@ module.exports = function (app, hexo) {
   }
 
   var use = function (path, fn) {
-    app.use(hexo.config.root + 'admin/api/' + path, function (req, res) {
+    app.use(urljoin(hexo.config.root, 'admin/api/', path), function (req, res) {
       var done = function (val) {
         if (!val) {
           res.statusCode = 204

--- a/auth/index.js
+++ b/auth/index.js
@@ -26,7 +26,7 @@ module.exports = function (app, hexo) {
       if (req.method === 'POST') {
           req.authenticate(['adminAuth'], function(error, done) {
               if (done) {
-                  res.writeHead(302, { 'Location':  "/admin/" });
+                  res.writeHead(302, { Location:  hexo.config.root + 'admin/' });
                   res.end();
               }
           });

--- a/auth/index.js
+++ b/auth/index.js
@@ -12,6 +12,7 @@ var cookieParser = require('cookie-parser')
   , auth = require('connect-auth')
   , path = require('path')
   , authStrategy = require('./strategy')
+  , urljoin = require('url-join');
 
 module.exports = function (app, hexo) {
   app.use(bodyParser.urlencoded({ extended: true }));
@@ -22,11 +23,11 @@ module.exports = function (app, hexo) {
       secret: hexo.config.admin.secret
   }));
   app.use(auth(authStrategy(hexo)));
-  app.use(hexo.config.root + 'admin/login', function (req, res) {
+  app.use(urljoin(hexo.config.root, 'admin/login'), function (req, res) {
       if (req.method === 'POST') {
           req.authenticate(['adminAuth'], function(error, done) {
               if (done) {
-                  res.writeHead(302, { Location:  hexo.config.root + 'admin/' });
+                  res.writeHead(302, { Location: urljoin(hexo.config.root, 'admin/') });
                   res.end();
               }
           });
@@ -34,7 +35,7 @@ module.exports = function (app, hexo) {
           serveStatic(path.join(__dirname, '../www', 'login'))(req, res);
       }
   });
-  app.use(hexo.config.root + 'admin/', function (req, res, next) {
+  app.use(urljoin(hexo.config.root, 'admin/'), function (req, res, next) {
       req.authenticate(['adminAuth'], next)
   });
 }

--- a/auth/index.js
+++ b/auth/index.js
@@ -22,7 +22,7 @@ module.exports = function (app, hexo) {
       secret: hexo.config.admin.secret
   }));
   app.use(auth(authStrategy(hexo)));
-  app.use(hexo.config.root + '/admin/login', function (req, res) {
+  app.use(hexo.config.root + 'admin/login', function (req, res) {
       if (req.method === 'POST') {
           req.authenticate(['adminAuth'], function(error, done) {
               if (done) {
@@ -34,7 +34,7 @@ module.exports = function (app, hexo) {
           serveStatic(path.join(__dirname, '../www', 'login'))(req, res);
       }
   });
-  app.use(hexo.config.root + '/admin/', function (req, res, next) {
+  app.use(hexo.config.root + 'admin/', function (req, res, next) {
       req.authenticate(['adminAuth'], next)
   });
 }

--- a/auth/strategy.js
+++ b/auth/strategy.js
@@ -1,10 +1,10 @@
 var md5 = require("MD5");
 
 module.exports = function (hexo) {
-    this.name = "adminAuth";
+    this.name = 'adminAuth';
 
     function failed_validation( request, response ) {
-        var redirectUrl= "/admin/login";
+        var redirectUrl= hexo.config.root + 'admin/login';
         response.writeHead(303, { 'Location':  redirectUrl });
         response.end();
     }

--- a/auth/strategy.js
+++ b/auth/strategy.js
@@ -1,10 +1,11 @@
 var md5 = require("MD5");
+var urljoin = require('url-join');
 
 module.exports = function (hexo) {
     this.name = 'adminAuth';
 
     function failed_validation( request, response ) {
-        var redirectUrl= hexo.config.root + 'admin/login';
+        var redirectUrl = urljoin(hexo.config.root, 'admin/login');
         response.writeHead(303, { 'Location':  redirectUrl });
         response.end();
     }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var serveStatic = require('serve-static'),
   bodyParser = require('body-parser'),
+  urljoin = require('url-join'),
   path = require('path'),
   api = require('./api');
 
@@ -25,8 +26,8 @@ hexo.extend.filter.register('server_middleware', function(app) {
   }
 
   // Main routes
-  app.use(hexo.config.root + 'admin/', serveStatic(path.join(__dirname, 'www')));
-  app.use(hexo.config.root + 'admin/api/', bodyParser.json({limit: '50mb'}));
+  app.use(urljoin(hexo.config.root, 'admin/'), serveStatic(path.join(__dirname, 'www')));
+  app.use(urljoin(hexo.config.root, 'admin/api/'), bodyParser.json({limit: '50mb'}));
 
   // setup the json api endpoints
   api(app, hexo);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "http://jaredly.github.io/hexo-admin/",
   "dependencies": {
-    "md5": "^2",
     "body-parser": "^1.5.0",
     "browserify": "^11.2.0",
     "connect-auth": "^0.6.1",
@@ -35,8 +34,10 @@
     "hexo-fs": "^0.1.3",
     "hexo-util": "^0.1.6",
     "less": "^2.5.1",
+    "md5": "^2",
     "moment": "^2.7.0",
-    "serve-static": "^1.4.0"
+    "serve-static": "^1.4.0",
+    "url-join": "0.0.1"
   },
   "devDependencies": {
     "code-mirror": "^3.22.0",


### PR DESCRIPTION
If "root" param in hexo config has to end with a "/" this is a fix for that in the auth component.

_Note: I'm still not sure 100% of that assumption but can't find any other documentation that mentions anything against it._