### PR TITLE
Native `hexo deploy` and `hexo generate` support from the admin. 

### DIFF
--- a/api.js
+++ b/api.js
@@ -4,6 +4,7 @@ var updateAny = require('./update')
   , updatePage = updateAny.bind(null, 'Page')
   , update = updateAny.bind(null, 'Post')
   , deploy = require('./deploy')
+  , generate = require('./generate')
 
 module.exports = function (app, hexo) {
 
@@ -256,21 +257,30 @@ module.exports = function (app, hexo) {
     })
   });
 
-  use('deploy', function(req, res, next) {
+  use('generate', function(req, res, next) {
     if (req.method !== 'POST') return next()
-    if (!hexo.config.admin || !hexo.config.admin.deployCommand) {
-      return res.done({error: 'Config value "admin.deployCommand" not found'});
-    }
     try {
-      deploy(hexo.config.admin.deployCommand, req.body.message, function(err, result) {
-        console.log('res', err, result);
+      generate(function(err, result) {
         if (err) {
           return res.done({error: err.message || err})
         }
         res.done(result);
       });
     } catch (e) {
-      console.log('EEE', e);
+      res.done({error: e.message})
+    }
+  });
+
+  use('deploy', function(req, res, next) {
+    if (req.method !== 'POST') return next()
+    try {
+      deploy(req.body.message, function(err, result) {
+        if (err) {
+          return res.done({error: err.message || err})
+        }
+        res.done(result);
+      });
+    } catch (e) {
       res.done({error: e.message})
     }
   });

--- a/api.js
+++ b/api.js
@@ -260,7 +260,7 @@ module.exports = function (app, hexo) {
   use('generate', function(req, res, next) {
     if (req.method !== 'POST') return next()
     try {
-      generate(function(err, result) {
+      generate(hexo.config, function(err, result) {
         if (err) {
           return res.done({error: err.message || err})
         }
@@ -274,7 +274,7 @@ module.exports = function (app, hexo) {
   use('deploy', function(req, res, next) {
     if (req.method !== 'POST') return next()
     try {
-      deploy(req.body.message, function(err, result) {
+      deploy(hexo.config, req.body.message, function(err, result) {
         if (err) {
           return res.done({error: err.message || err})
         }

--- a/client/api/rest.js
+++ b/client/api/rest.js
@@ -45,6 +45,7 @@ module.exports = function (baseUrl) {
       return get('/pages/' + id)
     },
     deploy: (message) => post('/deploy', {message: message}),
+    generate: () => post('/generate', {}),
     newPage: (title) => post('/pages/new', {title: title}),
     uploadImage: (data) => post('/images/upload', {data: data}),
     remove: (id) => post('/posts/' + id + '/remove'),
@@ -53,4 +54,3 @@ module.exports = function (baseUrl) {
     tagsAndCategories: () => get('/tags-and-categories'),
   }
 }
-

--- a/client/app.js
+++ b/client/app.js
@@ -12,7 +12,9 @@ var App = React.createClass({
           <li><Link to="posts">Posts</Link></li>
           <li><Link to="pages">Pages</Link></li>
           <li><Link to="about">About</Link></li>
-          <li><Link to="deploy">Deploy</Link></li>
+        </ul>
+        <ul className="app_nav pull-right">
+          <li><Link to="deploy"><i className="fa fa-refresh"></i> Sync</Link></li>
         </ul>
       </div>
       <div className="app_main">
@@ -23,4 +25,3 @@ var App = React.createClass({
 })
 
 module.exports = App
-

--- a/client/deploy.js
+++ b/client/deploy.js
@@ -16,28 +16,53 @@ var Deploy = React.createClass({
     };
   },
 
-  handleSubmit: function(e) {
-    e.preventDefault();
-    var message = this.state.message;
-    this.setState({
-      message: '',
-      error: null,
-      stdout: '',
-      stderr: '',
-      status: 'loading',
-    });
-    api.deploy(message).then(result => {
-      this.setState({
-        status: result.error ? 'error' : 'success',
-        error: result.error,
-        stdout: result.stdout && result.stdout.trim(),
-        stderr: result.stderr && result.stderr.trim(),
+  processOutput: function(prevData, newData) {
+    return {
+      status: newData.error ? 'error' : 'success',
+      error: newData.error,
+      stdout: (prevData ? prevData.stdout : '') + (newData ? newData.stdout.trim() : ''),
+      stderr: (prevData ? prevData.stderr : '') + (newData ? newData.stderr.trim() : '')
+    };
+  },
+
+  deploy: function(data) {
+    return new Promise((resolve, reject) => {
+      this.setState({status: 'loading'});
+      api.deploy(this.state.message).then(result => {
+        const output = this.processOutput(data, result);
+        resolve(output);
       });
     });
   },
 
+  generate: function(data) {
+    return new Promise((resolve, reject) => {
+      this.setState({status: 'loading'});
+      api.generate().then(result => {
+        const output = this.processOutput(data, result);
+        resolve(output);
+      });
+    });
+  },
+
+  handleDeploy: function(e) {
+    e.preventDefault();
+    this.deploy().then(result => this.setState(result));
+  },
+
+  handleGenerate: function(e) {
+    e.preventDefault();
+    this.generate().then(result => this.setState(result));
+  },
+
+  handleSync: function(e) {
+    e.preventDefault();
+    this.generate().then(result => this.deploy(result)).then(result => this.setState(result));
+  },
+
   render: function () {
-    var body;
+    var body = '';
+
     if (this.state.error) {
       body = <h4>Error: {this.state.error}</h4>
     } else if (this.state.status === 'loading') {
@@ -45,11 +70,11 @@ var Deploy = React.createClass({
     } else if (this.state.status === 'success') {
       body = (
         <div>
-          <h4>Std Output</h4>
+          <h4>Output</h4>
           <pre>
             {this.state.stdout}
           </pre>
-          <h4>Std Error</h4>
+          <h4>Error</h4>
           <pre>
             {this.state.stderr}
           </pre>
@@ -59,20 +84,42 @@ var Deploy = React.createClass({
 
     return (
       <div className="deploy" style={divStyle}>
-        <p>
-          Type a message here and hit `deploy` to run your deploy script.
-        </p>
-        <form className='deploy_form' onSubmit={this.handleSubmit}>
-          <input
-            type="text"
-            className="deploy_message"
-            value={this.state.message}
-            placeholder="Deploy/commit message"
-            onChange={e => this.setState({message: e.target.value})}
-          />
-          <input type="submit" value="Deploy" />
-        </form>
-        {body}
+        <div className="deploy_options">
+          <h1> Publish changes to server </h1>
+          <p>
+            Click here to sync your changes <i>(this will run hexo generate and hexo deploy)</i>
+          </p>
+          <form className='deploy_form' onSubmit={this.handleSync}>
+            <input
+              type="text"
+              className="deploy_message md"
+              value={this.state.message}
+              placeholder="Deploy message (optional)"
+              onChange={e => this.setState({message: e.target.value})}
+            />
+          <input type="submit" value="Generate and Deploy" />
+          </form>
+          <hr/>
+          <h5> <i className="fa fa-plus"></i> Advanced options</h5>
+          <form className='deploy_form' onSubmit={this.handleGenerate}>
+            <p>Click here to generate static files only: </p>
+            <input type="submit" value="Generate files" />
+          </form>
+          <form className='deploy_form' onSubmit={this.handleDeploy}>
+            <p>Type your deploy message here:</p>
+            <input
+              type="text"
+              className="deploy_message "
+              value={this.state.message}
+              placeholder="DDeploy/commit message"
+              onChange={e => this.setState({message: e.target.value})}
+            />
+            <input type="submit" value="Deploy" />
+          </form>
+        </div>
+        <div className="deploy_output">
+          {body}
+        </div>
       </div>
     )
     ;

--- a/client/deploy.js
+++ b/client/deploy.js
@@ -87,7 +87,7 @@ var Deploy = React.createClass({
         <div className="deploy_options">
           <h1> Publish changes to server </h1>
           <p>
-            Click here to sync your changes <i>(this will run hexo generate and hexo deploy)</i>
+            Click here to sync your changes <small>(this will run generate and deploy)</small>
           </p>
           <form className='deploy_form' onSubmit={this.handleSync}>
             <input
@@ -97,16 +97,17 @@ var Deploy = React.createClass({
               placeholder="Deploy message (optional)"
               onChange={e => this.setState({message: e.target.value})}
             />
-          <input type="submit" value="Generate and Deploy" />
+          <input type="submit" value="Publish" />
           </form>
           <hr/>
-          <h5> <i className="fa fa-plus"></i> Advanced options</h5>
+          <h4>Advanced options</h4>
           <form className='deploy_form' onSubmit={this.handleGenerate}>
-            <p>Click here to generate static files only: </p>
+            <p><b>Generate:</b></p>
             <input type="submit" value="Generate files" />
+            <small> (Click here to generate static files)</small>
           </form>
           <form className='deploy_form' onSubmit={this.handleDeploy}>
-            <p>Type your deploy message here:</p>
+            <p><b>Deploy:</b></p>
             <input
               type="text"
               className="deploy_message "
@@ -115,6 +116,7 @@ var Deploy = React.createClass({
               onChange={e => this.setState({message: e.target.value})}
             />
             <input type="submit" value="Deploy" />
+            <small> (Click here to deploy your static files)</small>
           </form>
         </div>
         <div className="deploy_output">

--- a/client/less/deploy.less
+++ b/client/less/deploy.less
@@ -1,6 +1,6 @@
 .deploy {
-  padding: 50px;
-  max-width: 600px;
+  flex: 1;
+  display: flex;
 
   &_form {
     margin-bottom: 20px;
@@ -16,5 +16,24 @@
 
   h1 {
     font-size: 2em;
+  }
+
+  input.md {
+    width: 400px;
+  }
+
+  .deploy_options {
+    background-color: @primaryVeryLight;
+    list-style: none;
+    padding: 30px;
+    margin: 0;
+    width: 50%;
+    overflow: auto;
+  }
+
+  .deploy_output {
+    padding: 30px;
+    display: flex;
+    position: relative;
   }
 }

--- a/deploy.js
+++ b/deploy.js
@@ -9,14 +9,19 @@ function once(fn) {
   }
 }
 
-module.exports = function (message, done) {
-  var options = ['deploy']
+module.exports = function (config, message, done) {
+
+  var deployCommand = config.admin && config.admin.deployCommand ? config.admin.deployCommand.split(' ') : [];
+  var command = deployCommand.length > 0 ? deployCommand[0] : 'hexo';
+  generateCommand.shift();
+  var options = deployCommand.length > 0 ? deployCommand : ['deploy'];
+
   if (message && message !== '') {
     options.push('-m ' + message + '');
   }
 
   done = once(done);
-  var proc = spawn('hexo', options, {detached: true});
+  var proc = spawn(command, options, {detached: true});
   var stdout = '';
   var stderr = '';
   proc.stdout.on('data', function(data){ stdout += data.toString() });

--- a/generate.js
+++ b/generate.js
@@ -9,9 +9,15 @@ function once(fn) {
   }
 }
 
-module.exports = function (done) {
+module.exports = function (config, done) {
   done = once(done);
-  var proc = spawn('hexo', ['generate'], {detached: true});
+
+  var generateCommand = config.admin && config.admin.generateCommand ? config.admin.generateCommand.split(' ') : [];
+  var command = generateCommand.length > 0 ? generateCommand[0] : 'hexo';
+  generateCommand.shift();
+  var options = generateCommand.length > 0 ? generateCommand : ['generate'];
+
+  var proc = spawn(command, options, {detached: true});
   var stdout = '';
   var stderr = '';
   proc.stdout.on('data', function(data){ stdout += data.toString() });

--- a/generate.js
+++ b/generate.js
@@ -9,14 +9,9 @@ function once(fn) {
   }
 }
 
-module.exports = function (message, done) {
-  var options = ['deploy']
-  if (message && message !== '') {
-    options.push('-m ' + message + '');
-  }
-
+module.exports = function (done) {
   done = once(done);
-  var proc = spawn('hexo', options, {detached: true});
+  var proc = spawn('hexo', ['generate'], {detached: true});
   var stdout = '';
   var stderr = '';
   proc.stdout.on('data', function(data){ stdout += data.toString() });


### PR DESCRIPTION
After reviewing the way the deploy was implemented I wanted to have support for native hexo commands like deploy and generate, and also keep the support for custom generate and deploy commands

- Added generateCommand (now we have generateCommand and deployCommand under admin in _config.yml)
- If generateCommand is not defined will run `hexo generate` 
- If deployCommand is not defined will run `hexo deploy` 
- Modify interface for deploy

<img width="1407" alt="screenshot 2015-12-24 10 11 43" src="https://cloud.githubusercontent.com/assets/1236638/11993333/752a41ac-aa27-11e5-9951-579f9b327eda.png">

_UI is not that pretty yet. Would love to have more CSS work there but didn't want to make the PR longer and focus on the subject_