### PR TITLE
Update package.json and code-mirror for new version of CodeMirror

### DIFF
--- a/client/code-mirror.js
+++ b/client/code-mirror.js
@@ -1,6 +1,6 @@
 
 var React = require('react')
-var CM = require('code-mirror')
+var CM = require('codemirror')
 var PT = React.PropTypes
 var api = require('./api')
 
@@ -16,10 +16,10 @@ var CodeMirror = React.createClass({
   },
 
   componentDidMount: function () {
-    require('code-mirror/mode/markdown')
+    require('codemirror/mode/markdown/markdown')
     this.cm = CM(this.getDOMNode(), {
       value: this.props.initialValue || '',
-      theme: require('code-mirror/theme/default'),
+      theme: 'default',
       mode: 'markdown',
       lineWrapping: true,
     });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "serve-static": "^1.4.0"
   },
   "devDependencies": {
-    "code-mirror": "^3.22.0",
+    "codemirror": "^5.10.0",
     "es6-promise": "^1.0.0",
     "react": "^0.11.1",
     "react-router": "^0.4.1",


### PR DESCRIPTION
Since I have to compile the bundle.js by myself, I found that the usage of codemirror is outdated. I have changed the code and now it can correctly compiled.