### PR TITLE
Fix for issue 47 (Can't create new post on windows)

### DIFF
--- a/api.js
+++ b/api.js
@@ -183,7 +183,7 @@ module.exports = function (app, hexo) {
     .then(function (file) {
       var source = file.path.slice(hexo.source_dir.length)
       hexo.source.process([source]).then(function () {
-        var post = hexo.model('Post').findOne({source: source})
+        var post = hexo.model('Post').findOne({source: source.replace(/\\/g, '\/')})
         res.done(addIsDraft(post));
       });
     });


### PR DESCRIPTION
[Here's a link to the original issue](https://github.com/jaredly/hexo-admin/issues/47)

Paths are stored in database in UNIX-format (using ordinary dash as directory separator).
File path on Windows are using back-dash instead of ordinary one - that's why the search query fails to return a post.

Fixed by replacing all back-dashes with an ordinary ones in the `source` var when passing it to the DB query