### PR TITLE
upgraded to latest CodeMirror (v5.20.2)

### DIFF
--- a/client/code-mirror.js
+++ b/client/code-mirror.js
@@ -1,6 +1,6 @@
 
 var React = require('react')
-var CM = require('code-mirror')
+var CM = require('codemirror/lib/codemirror')
 var PT = React.PropTypes
 var api = require('./api')
 
@@ -16,10 +16,10 @@ var CodeMirror = React.createClass({
   },
 
   componentDidMount: function () {
-    require('code-mirror/mode/markdown')
+    require('codemirror/mode/markdown/markdown')
     this.cm = CM(this.getDOMNode(), {
       value: this.props.initialValue || '',
-      theme: require('code-mirror/theme/default'),
+      theme: 'default',
       mode: 'markdown',
       lineWrapping: true,
     });

--- a/client/less/code-mirror.less
+++ b/client/less/code-mirror.less
@@ -1,79 +1,365 @@
 
 /* DEFAULT THEME */
-@blue: rgb(115, 115, 255);
-@darkgrey: #555;
-
 .CodeMirror {
-  color: lighten(@darkgrey, 10%);
-  .CodeMirror-focused,
-  .CodeMirror-selected {
-    color: @darkgrey;
-    background: lighten(@blue, 20%);
-    text-shadow: none;
+  font-family:monospace;
+  height:300px;
+  color:black;
+  position:relative;
+  overflow:hidden;
+  background:white;
+  pre {
+    padding:0 4px;
+    -moz-border-radius:0;
+    -webkit-border-radius:0;
+    border-radius:0;
+    border-width:0;
+    background:transparent;
+    font-family:inherit;
+    font-size:inherit;
+    margin:0;
+    white-space:pre;
+    word-wrap:normal;
+    line-height:inherit;
+    color:inherit;
+    z-index:2;
+    position:relative;
+    overflow:visible;
+    -webkit-tap-highlight-color:transparent;
+    -webkit-font-variant-ligatures:none;
+    font-variant-ligatures:none;
   }
-
-  ::selection {
-    color: @darkgrey;
-    background: lighten(@blue, 20%);
-    text-shadow: none;
+  div.CodeMirror-secondarycursor {
+    border-left:1px solid silver;
   }
-
-  .cm-s-default .cm-keyword {color: #708;}
-  .cm-s-default .cm-atom {color: #219;}
-  .cm-s-default .cm-number {color: #164;}
-  .cm-s-default .cm-def {color: #00f;}
-  .cm-s-default .cm-variable {color: black;}
-  .cm-s-default .cm-variable-2 {color: #05a;}
-  .cm-s-default .cm-variable-3 {color: #085;}
-  .cm-s-default .cm-property {color: black;}
-  .cm-s-default .cm-operator {color: black;}
-  .cm-s-default .cm-comment {color: #a50;}
-  .cm-s-default .cm-string {color: #a11;}
-  .cm-s-default .cm-string-2 {color: #f50;}
-  .cm-s-default .cm-meta {color: #555;}
-  .cm-s-default .cm-error {color: #f00;}
-  .cm-s-default .cm-qualifier {color: #555;}
-  .cm-s-default .cm-builtin {color: #30a;}
-  .cm-s-default .cm-bracket {color: #997;}
-  .cm-s-default .cm-tag {color: #170;}
-  .cm-s-default .cm-attribute {color: #00c;}
-  .cm-s-default .cm-header {color: blue;}
-  .cm-s-default .cm-quote {color: #090;}
-  .cm-s-default .cm-hr {color: #999;}
-  .cm-s-default .cm-link {color: #00c;}
-
-  .cm-negative {color: #d44;}
-  .cm-positive {color: #292;}
-  .cm-header, .cm-strong {font-weight: bold;}
-  .cm-em {font-style: italic;}
-  .cm-link {text-decoration: underline;}
-
-  .cm-invalidchar {color: #f00;}
-
-
+}
+.CodeMirror-lines {
+  padding:4px 0;
+  cursor:text;
+  min-height:1px;
+}
+.CodeMirror-scrollbar-filler {
+  background-color:white;
+  position:absolute;
+  z-index:6;
+  display:none;
+  right:0;
+  bottom:0;
+}
+.CodeMirror-gutter-filler {
+  background-color:white;
+  position:absolute;
+  z-index:6;
+  display:none;
+  left:0;
+  bottom:0;
+}
+.CodeMirror-gutters {
+  border-right:1px solid #dddddd;
+  background-color:#f7f7f7;
+  white-space:nowrap;
+  position:absolute;
+  left:0;
+  top:0;
+  min-height:100%;
+  z-index:3;
+  -moz-box-sizing:content-box;
+  box-sizing:content-box;
+}
+.CodeMirror-linenumbers {
+}
+.CodeMirror-linenumber {
+  padding:0 3px 0 5px;
+  min-width:20px;
+  text-align:right;
+  color:#999999;
+  white-space:nowrap;
+  -moz-box-sizing:content-box;
+  box-sizing:content-box;
+}
+.CodeMirror-guttermarker {
+  color:black;
+}
+.CodeMirror-guttermarker-subtle {
+  color:#999999;
+}
+.CodeMirror-cursor {
+  border-left:1px solid black;
+  border-right:none;
+  width:0;
+  position:absolute;
+  pointer-events:none;
+}
+.cm-fat-cursor .CodeMirror-cursor {
+  width:auto;
+  border:0 !important;
+  background:#77ee77;
+}
+.cm-fat-cursor div.CodeMirror-cursors {
+  z-index:1;
+}
+.cm-animate-fat-cursor {
+  width:auto;
+  border:0;
+  -webkit-animation:blink 1.06s steps(1) infinite;
+  -moz-animation:blink 1.06s steps(1) infinite;
+  animation:blink 1.06s steps(1) infinite;
+  background-color:#77ee77;
+}
+.CodeMirror-overwrite .CodeMirror-cursor {
+}
+.cm-tab {
+  display:inline-block;
+  text-decoration:inherit;
+}
+.CodeMirror-rulers {
+  position:absolute;
+  left:0;
+  right:0;
+  top:-50px;
+  bottom:-20px;
+  overflow:hidden;
+}
+.CodeMirror-ruler {
+  border-left:1px solid #cccccc;
+  top:0;
+  bottom:0;
+  position:absolute;
+}
+.cm-s-default {
+  .cm-variable, .cm-punctuation, .cm-property, .cm-operator {
+  }
   .cm-header {
-    color: #000;
-    font-size: 1.4em;
-    line-height: 1.4em;
-    font-weight: bold;
-      }
-
-      .cm-variable-2,
-      .cm-variable-3,
-      .cm-keyword {
-        color: lighten(@darkgrey, 10%);
-      }
-
-      .cm-string,
-      .cm-strong,
-      .cm-link,
-      .cm-comment,
-      .cm-quote,
-      .cm-number,
-      .cm-atom,
-      .cm-tag {
-        color: #000;
-        font-weight: bold;
-      }
-
+    color:blue;
+  }
+  .cm-quote {
+    color:#009900;
+  }
+  .cm-keyword {
+    color:#770088;
+  }
+  .cm-atom {
+    color:#221199;
+  }
+  .cm-number {
+    color:#116644;
+  }
+  .cm-def {
+    color:#0000ff;
+  }
+  .cm-variable-2 {
+    color:#0055aa;
+  }
+  .cm-variable-3 {
+    color:#008855;
+  }
+  .cm-comment {
+    color:#aa5500;
+    font-size:1em;
+    font-weight:500;
+  }
+  .cm-string {
+    color:#aa1111;
+  }
+  .cm-string-2 {
+    color:#ff5500;
+  }
+  .cm-meta {
+    color:#555555;
+  }
+  .cm-qualifier {
+    color:#555555;
+  }
+  .cm-builtin {
+    color:#3300aa;
+  }
+  .cm-bracket {
+    color:#999977;
+  }
+  .cm-tag {
+    color:#117700;
+  }
+  .cm-attribute {
+    color:#0000cc;
+  }
+  .cm-hr {
+    color:#999999;
+  }
+  .cm-link {
+    color:#0000cc;
+  }
+  .cm-error {
+    color:#ff0000;
+  }
+}
+.cm-negative {
+  color:#dd4444;
+}
+.cm-positive {
+  color:#229922;
+}
+.cm-header, .cm-strong {
+  font-weight:bold;
+}
+.cm-em {
+  font-style:italic;
+}
+.cm-link {
+  text-decoration:underline;
+}
+.cm-strikethrough {
+  text-decoration:line-through;
+}
+.cm-invalidchar {
+  color:#ff0000;
+}
+.CodeMirror-composing {
+  border-bottom:2px solid;
+}
+div.CodeMirror span.CodeMirror-matchingbracket {
+  color:#00ff00;
+}
+div.CodeMirror span.CodeMirror-nonmatchingbracket {
+  color:#ff2222;
+}
+.CodeMirror-matchingtag {
+  background:rgba(255,150,0,0.3);
+}
+.CodeMirror-activeline-background {
+  background:#e8f2ff;
+}
+.CodeMirror-scroll {
+  overflow:scroll !important;
+  margin-bottom:-30px;
+  margin-right:-30px;
+  padding-bottom:30px;
+  height:100%;
+  outline:none;
+  position:relative;
+  -moz-box-sizing:content-box;
+  box-sizing:content-box;
+}
+.CodeMirror-sizer {
+  position:relative;
+  border-right:30px solid transparent;
+  -moz-box-sizing:content-box;
+  box-sizing:content-box;
+}
+.CodeMirror-vscrollbar {
+  position:absolute;
+  z-index:6;
+  display:none;
+  right:0;
+  top:0;
+  overflow-x:hidden;
+  overflow-y:scroll;
+}
+.CodeMirror-hscrollbar {
+  position:absolute;
+  z-index:6;
+  display:none;
+  bottom:0;
+  left:0;
+  overflow-y:hidden;
+  overflow-x:scroll;
+}
+.CodeMirror-gutter {
+  white-space:normal;
+  height:100%;
+  display:inline-block;
+  vertical-align:top;
+  margin-bottom:-30px;
+  -moz-box-sizing:content-box;
+  box-sizing:content-box;
+}
+.CodeMirror-gutter-wrapper {
+  position:absolute;
+  z-index:4;
+  background:none !important;
+  border:none !important;
+  -webkit-user-select:none;
+  -moz-user-select:none;
+  user-select:none;
+}
+.CodeMirror-gutter-background {
+  position:absolute;
+  top:0;
+  bottom:0;
+  z-index:4;
+}
+.CodeMirror-gutter-elt {
+  position:absolute;
+  cursor:default;
+  z-index:4;
+}
+.CodeMirror-wrap pre {
+  word-wrap:break-word;
+  white-space:pre-wrap;
+  word-break:normal;
+}
+.CodeMirror-linebackground {
+  position:absolute;
+  left:0;
+  right:0;
+  top:0;
+  bottom:0;
+  z-index:0;
+}
+.CodeMirror-linewidget {
+  position:relative;
+  z-index:2;
+  overflow:auto;
+}
+.CodeMirror-widget {
+}
+.CodeMirror-code {
+  outline:none;
+}
+.CodeMirror-measure {
+  position:absolute;
+  width:100%;
+  height:0;
+  overflow:hidden;
+  visibility:hidden;
+  pre {
+    position:static;
+  }
+}
+div.CodeMirror-cursors {
+  visibility:hidden;
+  position:relative;
+  z-index:3;
+}
+div.CodeMirror-dragcursors {
+  visibility:visible;
+}
+.CodeMirror-focused div.CodeMirror-cursors {
+  visibility:visible;
+}
+.CodeMirror-focused .CodeMirror-selected {
+  background:#d7d4f0;
+}
+.CodeMirror-selected {
+  background:#d9d9d9;
+}
+.CodeMirror-crosshair {
+  cursor:crosshair;
+}
+.CodeMirror-line::selection, .CodeMirror-line > span::selection, .CodeMirror-line > span > span::selection {
+  background:#d7d4f0;
+}
+.CodeMirror-line::-moz-selection, .CodeMirror-line > span::-moz-selection, .CodeMirror-line > span > span::-moz-selection {
+  background:#d7d4f0;
+}
+.cm-searching {
+  background:#ffffaa;
+  background:rgba(255,255,0,0.4);
+}
+.cm-force-border {
+  padding-right:.1px;
+}
+.cm-tab-wrap-hack:after {
+  content:'';
+}
+span.CodeMirror-selectedtext {
+  background:none;
 }

--- a/client/less/editor.less
+++ b/client/less/editor.less
@@ -142,7 +142,7 @@
   display: flex;
   flex-direction: column;
   font-family: Inconsolata;
-  padding: 0 20px;
+  padding: 40px 20px 0;
   font-size: 18px;
   position: relative;
   min-width: 0;
@@ -216,4 +216,3 @@
 .cm-header-4 {
   font-size: 1.3em;
 }
-

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "browserify": "^11.2.0",
-    "code-mirror": "^3.22.0",
+    "codemirror": "^5.20.2",
     "es6-promise": "^1.0.0",
     "gulp": "^3.9.1",
     "gulp-less": "^3.0.5",


### PR DESCRIPTION
Everything works as it did, but now we get the added benefit of 2.5 years of :sparkles: updates to  [CodeMirror](https://github.com/codemirror/CodeMirror/) :sparkles:. I needed to update `codemirror.less` as they're CSS defaults have changed and the styles from v3.22.0 breaks the new version.

Note that codemirror changed their `npm` module name from `code-mirror` to `codemirror` around the release of v4.
