### PR TITLE
Pasted image settings

### DIFF
--- a/api.js
+++ b/api.js
@@ -307,9 +307,11 @@ module.exports = function (app, hexo) {
     var imagePath = '/images'
     var imagePrefix = 'pasted-'
     var askImageFilename = false
+    var overwriteImages = false
     // check for image settings and set them if they exist
     if (settings.options) {
       askImageFilename = !!settings.options.askImageFilename
+      overwriteImages = !!settings.options.overwriteImages
       imagePath = settings.options.imagePath ? settings.options.imagePath : imagePath
       imagePrefix = settings.options.imagePrefix ? settings.options.imagePrefix : imagePrefix
     }
@@ -329,8 +331,14 @@ module.exports = function (app, hexo) {
       }
       hexo.log.d('trying custom filename', givenFilename)
       if (fs.existsSync(path.join(hexo.source_dir, imagePath, givenFilename))){
-        hexo.log.d('file already exists, using', filename)
-        msg = 'filename already exists, renamed'
+        if (overwriteImages) {
+          hexo.log.d('file already exists, overwriting')
+          msg = 'overwrote existing file'
+          filename = givenFilename
+        } else {
+          hexo.log.d('file already exists, using', filename)
+          msg = 'filename already exists, renamed'
+        }
       } else {
         filename = givenFilename
       }

--- a/client/api/rest.js
+++ b/client/api/rest.js
@@ -46,7 +46,7 @@ module.exports = function (baseUrl) {
     },
     deploy: (message) => post('/deploy', {message: message}),
     newPage: (title) => post('/pages/new', {title: title}),
-    uploadImage: (data) => post('/images/upload', {data: data}),
+    uploadImage: (data, filename) => post('/images/upload', {data: data, filename: filename}),
     remove: (id) => post('/posts/' + id + '/remove'),
     publish: (id) => post('/posts/' + id + '/publish'),
     unpublish: (id) => post('/posts/' + id + '/unpublish'),

--- a/client/code-mirror.js
+++ b/client/code-mirror.js
@@ -79,10 +79,8 @@ var CodeMirror = React.createClass({
         }
       }
       console.log(filename)
-      api.uploadImage(event.target.result, filename).then((src) =>
-        // console.log(src)
-        // href.location = src.data.toString()
-        this.cm.replaceSelection('![pasted image](' + src + ')')
+      api.uploadImage(event.target.result, filename).then((res) =>
+        this.cm.replaceSelection(`\n![${res.msg}](${res.src})`)
       );
     };
     reader.readAsDataURL(blob);

--- a/client/code-mirror.js
+++ b/client/code-mirror.js
@@ -7,7 +7,7 @@ var api = require('./api')
 var CodeMirror = React.createClass({
   propTypes: {
     onScroll: PT.func,
-    editorSettings: PT.object
+    adminSettings: PT.object
   },
 
   componentDidUpdate: function (prevProps) {
@@ -25,8 +25,8 @@ var CodeMirror = React.createClass({
       mode: 'markdown',
       lineWrapping: true,
     }
-    for (var key in this.props.editorSettings) {
-      editorSettings[key] = this.props.editorSettings[key]
+    for (var key in this.props.adminSettings.editor) {
+      editorSettings[key] = this.props.adminSettings.editor[key]
     }
 
     this.cm = CM(this.getDOMNode(), editorSettings);
@@ -67,9 +67,21 @@ var CodeMirror = React.createClass({
       }
     };
     if (!blob) return
+
+    var settings = this.props.adminSettings
     var reader = new FileReader();
     reader.onload = (event) => {
-      api.uploadImage(event.target.result).then((src) =>
+      var filename = null;
+      if (settings.options) {
+        if(!!settings.options.askImageFilename) {
+          var filePath = !!settings.options.imagePath ? settings.options.imagePath : '/images'
+          filename = prompt(`What would you like to name the photo? All files saved as pngs. Name will be relative to ${filePath}.`, 'image.png')
+        }
+      }
+      console.log(filename)
+      api.uploadImage(event.target.result, filename).then((src) =>
+        // console.log(src)
+        // href.location = src.data.toString()
         this.cm.replaceSelection('![pasted image](' + src + ')')
       );
     };

--- a/client/editor.js
+++ b/client/editor.js
@@ -19,7 +19,7 @@ var Editor = React.createClass({
     onPublish: PT.func.isRequired,
     onUnpublish: PT.func.isRequired,
     tagsAndCategories: PT.object,
-    editorSettings: PT.object
+    adminSettings: PT.object
   },
 
   handleChangeTitle: function (e) {
@@ -72,7 +72,7 @@ var Editor = React.createClass({
             onScroll={this.handleScroll}
             initialValue={this.props.raw}
             onChange={this.props.onChangeContent}
-            editorSettings={this.props.editorSettings} />
+            adminSettings={this.props.adminSettings} />
         </div>
         <div className="editor_display">
           <div className="editor_display-header">

--- a/client/less/settings.less
+++ b/client/less/settings.less
@@ -1,12 +1,20 @@
 .settings {
   padding: 50px;
-  max-width: 600px;
+
+  hr {
+    margin: 1.5em 0
+  }
 
   p {
     margin-bottom: 1em;
+    margin-top: 10px
   }
 
   h1 {
     font-size: 2em;
+  }
+
+  h2 {
+    font-size: 1.7em
   }
 }

--- a/client/page.js
+++ b/client/page.js
@@ -115,7 +115,7 @@ var Page = React.createClass({
       onChangeTitle: this.handleChangeTitle,
       onPublish: this.handlePublish,
       onUnpublish: this.handleUnpublish,
-      editorSettings: settings.editor,
+      adminSettings: settings
     })
   }
 });

--- a/client/post.js
+++ b/client/post.js
@@ -127,7 +127,7 @@ var Post = React.createClass({
       onUnpublish: this.handleUnpublish,
       onRemove: this.handleRemove,
       tagsAndCategories: this.state.tagsAndCategories,
-      editorSettings: settings.editor
+      adminSettings: settings
     })
   }
 });

--- a/client/settings-checkbox.js
+++ b/client/settings-checkbox.js
@@ -6,8 +6,8 @@ var api = require('./api')
 var SettingsCheckbox = React.createClass({
   propTypes: {
     name: PT.string.isRequired,
-    enableOptions: PT.object.isRequired,
-    disableOptions: PT.object.isRequired,
+    enableOptions: PT.object,
+    disableOptions: PT.object,
     label: PT.string.isRequired,
     onClick: PT.func
   },

--- a/client/settings-checkbox.js
+++ b/client/settings-checkbox.js
@@ -6,22 +6,23 @@ var api = require('./api')
 var SettingsCheckbox = React.createClass({
   propTypes: {
     name: PT.string.isRequired,
+    label: PT.string.isRequired,
+    style: PT.object,
     enableOptions: PT.object,
     disableOptions: PT.object,
-    label: PT.string.isRequired,
     onClick: PT.func
   },
 
   getInitialState: function () {
     return {
-      checked: true
+      checked: false,
     }
   },
 
   componentDidMount: function() {
     var name = this.props.name
     api.settings().then( (settings) => {
-      var checked;
+      var checked
       if (!settings.options) {
         checked = false
       } else {
@@ -46,7 +47,7 @@ var SettingsCheckbox = React.createClass({
 
   render: function() {
     return (
-      <p>
+      <p style={this.props.style}>
       <label>
           <input
             checked={this.state.checked}

--- a/client/settings-textbox.js
+++ b/client/settings-textbox.js
@@ -1,0 +1,62 @@
+
+var React = require('react/addons')
+var PT = React.PropTypes
+var api = require('./api')
+
+var SettingsTextbox = React.createClass({
+  propTypes: {
+    name: PT.string.isRequired,
+    defaultValue: PT.string.isRequired,
+    label: PT.string.isRequired
+  },
+
+  getInitialState: function () {
+    return {
+      value: this.props.defaultValue
+    }
+  },
+
+  componentDidMount: function() {
+    var name = this.props.name
+    var defaultValue = this.props.defaultValue
+    api.settings().then( (settings) => {
+      var value;
+      if (!settings.options) {
+        value = defaultValue
+      } else {
+        if(!settings.options[name]) {
+          value = defaultValue
+        } else {
+          value = settings.options[name]
+        }
+      }
+      this.setState({value: value})
+    })
+  },
+
+  handleChange: function(e) {
+    var name = this.props.name
+    var value = e.target.value
+    api.setSetting(name, value).then( (result) => {
+      console.log(result.updated)
+      this.setState({
+        value: result.settings.options[name]
+      });
+    });
+  },
+
+  render: function() {
+    return (
+      <p>
+        <b>{this.props.label}:  </b>
+        <input
+          type="text"
+          onChange={this.handleChange}
+          value ={this.state.value}
+        />
+      </p>
+    );
+  }
+});
+
+module.exports = SettingsTextbox

--- a/client/settings.js
+++ b/client/settings.js
@@ -1,6 +1,5 @@
 
 var React = require('react/addons')
-var api = require('./api')
 var SettingsCheckbox = require('./settings-checkbox')
 var SettingsTextbox = require('./settings-textbox')
 
@@ -10,11 +9,7 @@ var divStyle = {
 
 var Settings = React.createClass({
   getInitialState: function() {
-    return {
-      updated: null,
-      error: null,
-      status: 'initial',
-    };
+    return {};
   },
 
   render: function () {
@@ -32,10 +27,17 @@ var Settings = React.createClass({
       label: 'Enable spellchecking. (buggy on older browsers)'
     });
 
-    var ImageAskToSave = SettingsCheckbox({
+    var AskImageFilename = SettingsCheckbox({
       name: 'askImageFilename',
-      label: 'Always ask for filename.'
+      label: 'Always ask for filename.',
+      style: {width: '300px', display: 'inline-block'}
     });
+
+    var OverwriteImages = SettingsCheckbox({
+      name: 'overwriteImages',
+      label: 'Overwrite images if file already exists.',
+      style: {width: '425px', display: 'inline-block'}
+    })
 
     var ImagePath = SettingsTextbox({
       name: 'imagePath',
@@ -55,18 +57,22 @@ var Settings = React.createClass({
         <p>
           Set various settings for your admin panel and editor.
         </p>
+        <hr />
+
         <h2>Editor Settings</h2>
         {LineNumbers}
         {SpellCheck}
+        <hr />
+
         <h2>Image Pasting Settings</h2>
         <p>
           Hexo-admin allows you to paste images you copy from the web or elsewhere directly
           into the editor. Decide how you'd like to handle the pasted images.
         </p>
-        {ImageAskToSave}
+        {AskImageFilename}
+        {OverwriteImages}
         {ImagePath}
         {ImagePrefix}
-
       </div>
     );
   }

--- a/client/settings.js
+++ b/client/settings.js
@@ -2,6 +2,7 @@
 var React = require('react/addons')
 var api = require('./api')
 var SettingsCheckbox = require('./settings-checkbox')
+var SettingsTextbox = require('./settings-textbox')
 
 var divStyle = {
   whiteSpace: 'nowrap'
@@ -31,14 +32,41 @@ var Settings = React.createClass({
       label: 'Enable spellchecking. (buggy on older browsers)'
     });
 
+    var ImageAskToSave = SettingsCheckbox({
+      name: 'askImageFilename',
+      label: 'Always ask for filename.'
+    });
+
+    var ImagePath = SettingsTextbox({
+      name: 'imagePath',
+      defaultValue: '/images',
+      label: 'Image directory'
+    });
+
+    var ImagePrefix = SettingsTextbox({
+      name: 'imagePrefix',
+      defaultValue: 'pasted-',
+      label: 'Image filename prefix'
+    });
+
     return (
       <div className="settings" style={divStyle}>
+        <h1>Settings</h1>
         <p>
           Set various settings for your admin panel and editor.
         </p>
-        <h1>Editor Settings</h1>
+        <h2>Editor Settings</h2>
         {LineNumbers}
         {SpellCheck}
+        <h2>Image Pasting Settings</h2>
+        <p>
+          Hexo-admin allows you to paste images you copy from the web or elsewhere directly
+          into the editor. Decide how you'd like to handle the pasted images.
+        </p>
+        {ImageAskToSave}
+        {ImagePath}
+        {ImagePrefix}
+
       </div>
     );
   }


### PR DESCRIPTION
 # Add settings for pasted images

 On the settings page:

![custom image settings](https://cloud.githubusercontent.com/assets/14897503/21462527/b292f596-c922-11e6-81a6-a6d49b43110b.png)

You can change the default pasted-image naming scheme by choosing a directory other than `/images`, and a prefix other than `pasted-` for automatically named images.

You can also have the editor ask you what you want to name the file, with an additional option for overwriting the file if it already exists.

## Paste without asking filename

It works the exact same, only it automatically names the file according to your scheme, which also hasn't changed from the previous default.

## Paste with asking for a filename

Upon pasting, a dialog asks you the name.

![pasting with filename](https://cloud.githubusercontent.com/assets/14897503/21462613/b49cf516-c923-11e6-8538-f8be345e33a1.png)

## Editor behavior

Below is what it looks like if you paste without choosing the filename, and then paste with choosing the filename. If you choose a filename that already exists without allowing for overwriting it reverts back to the default naming scheme:

![pasting images](https://cloud.githubusercontent.com/assets/14897503/21462655/1322c444-c924-11e6-9e7a-de82d521d40b.png)


