### PR TITLE
authentification works and you no longer need a password_hash in config

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,13 +43,10 @@ protection. To enable this, you just add a few config variables to your hexo
 ```
 admin:
   username: myfavoritename
-  password_hash: be121740bf988b2225a313fa1f107ca1
   secret: a secret something
 ```
 
-The `password_hash` is the bcrypt hash of your password. You can use [this
-site](https://www.bcrypt-generator.com/) to come up with that, or whatever you
-want. The `secret` is used to make the cookies secure, so it's a good idea to
+The `secret` is used to make the cookies secure, so it's a good idea to
 have it be long and complicated.
 
 Once that's in place, start up your hexo server and going to `/admin/` will

--- a/auth/strategy.js
+++ b/auth/strategy.js
@@ -11,8 +11,9 @@ module.exports = function (hexo) {
 
     function validate_credentials( executionScope, request, response, callback ) {
         var config = hexo.config.admin
+        var passwordHash = bcrypt.hashSync(config.secret)
         if (request.body.username == config.username &&
-            bcrypt.compareSync(request.body.password, config.password_hash)) {
+            bcrypt.compareSync(request.body.password, passwordHash)) {
             executionScope.success({name:request.body.user}, callback)
         }
         else {


### PR DESCRIPTION
Fixes #103.

The hash generator online no longer jives with the one used by `bcrypt-nodejs`, so all password hash-secret combinations fail and throw an "Invalid salt revision" error.

I changed it so that the backend generates the hash to compare to. This means the `admin` section of `_config.yml` no longer needs a `password_hash`.