### PR TITLE
Ability to change filenames of posts & pages from editor

### DIFF
--- a/api.js
+++ b/api.js
@@ -82,6 +82,18 @@ module.exports = function (app, hexo) {
     }, hexo)
   }
 
+  function rename(id, body, res) {
+    var post = hexo.model('Post').get(id)
+    if (!post) return res.send(404, "Post not found")
+    update(id, {source: body.filename}, function (err, post) {
+      if (err) {
+        return res.send(400, err);
+      }
+      hexo.log.d(`renamed post to ${body.filename}`)
+      res.done(addIsDraft(post))
+    }, hexo)
+  }
+
   var use = function (path, fn) {
     app.use(hexo.config.root + 'admin/api/' + path, function (req, res) {
       var done = function (val) {
@@ -268,6 +280,9 @@ module.exports = function (app, hexo) {
     }
     if (last === 'remove') {
       return remove(parts[parts.length-2], req.body, res)
+    }
+    if (last === 'rename') {
+      return rename(parts[parts.length-2], req.body, res)
     }
 
     var id = last

--- a/client/api/rest.js
+++ b/client/api/rest.js
@@ -50,6 +50,9 @@ module.exports = function (baseUrl) {
     remove: (id) => post('/posts/' + id + '/remove'),
     publish: (id) => post('/posts/' + id + '/publish'),
     unpublish: (id) => post('/posts/' + id + '/unpublish'),
+    renamePost: (id, filename) => post('/posts/' + id + '/rename', {
+      filename: filename
+    }),
     tagsAndCategories: () => get('/tags-and-categories'),
     settings: () => get('/settings/list'),
     setSetting: (name, value, addedOptions) => post('/settings/set', {

--- a/client/editor.js
+++ b/client/editor.js
@@ -7,6 +7,7 @@ var CodeMirror = require('./code-mirror')
 var SinceWhen = require('./since-when')
 var Rendered = require('./rendered')
 var ConfigDropper = require('./config-dropper')
+var RenameFile = require('./rename-file')
 
 var Editor = React.createClass({
   propTypes: {
@@ -66,7 +67,8 @@ var Editor = React.createClass({
                 <SinceWhen className="editor_updated"
                 prefix="saved "
                 time={this.props.updated}/>}
-            Markdown
+            <span>Markdown&nbsp;&nbsp;
+            {!this.props.isPage && <RenameFile post={this.props.post} />}</span>
           </div>
           <CodeMirror
             onScroll={this.handleScroll}

--- a/client/editor.js
+++ b/client/editor.js
@@ -1,4 +1,5 @@
 
+var path = require('path')
 var React = require('react/addons')
 var cx = React.addons.classSet
 var Promise = require('es6-promise').Promise
@@ -21,6 +22,21 @@ var Editor = React.createClass({
     onUnpublish: PT.func.isRequired,
     tagsAndCategories: PT.object,
     adminSettings: PT.object
+  },
+
+  getInitialState: function() {
+    var url = window.location.pathname.split('/')
+    var rootPath = url.slice(0, url.indexOf('admin')).join('/')
+    return {
+      previewLink: path.join(rootPath, this.props.post.path)
+    }
+  },
+
+  handlePreviewLink: function(previewLink) {
+    console.log('updating preview link')
+    this.setState({
+      previewLink: path.join(previewLink)
+    })
   },
 
   handleChangeTitle: function (e) {
@@ -68,7 +84,9 @@ var Editor = React.createClass({
                 prefix="saved "
                 time={this.props.updated}/>}
             <span>Markdown&nbsp;&nbsp;
-            {!this.props.isPage && <RenameFile post={this.props.post} />}</span>
+            {!this.props.isPage &&
+              <RenameFile post={this.props.post}
+                handlePreviewLink={this.handlePreviewLink} />}</span>
           </div>
           <CodeMirror
             onScroll={this.handleScroll}
@@ -82,8 +100,8 @@ var Editor = React.createClass({
               {this.props.wordCount} words
             </span>
             Preview
-            {' '}<a className="editor_perma-link" href={this.props.previewLink} target="_blank">
-              <i className="fa fa-link"/> {this.props.previewLink}
+            {' '}<a className="editor_perma-link" href={this.state.previewLink} target="_blank">
+              <i className="fa fa-link"/> {this.state.previewLink}
             </a>
           </div>
           <Rendered

--- a/client/editor.js
+++ b/client/editor.js
@@ -84,9 +84,8 @@ var Editor = React.createClass({
                 prefix="saved "
                 time={this.props.updated}/>}
             <span>Markdown&nbsp;&nbsp;
-            {!this.props.isPage &&
               <RenameFile post={this.props.post}
-                handlePreviewLink={this.handlePreviewLink} />}</span>
+                handlePreviewLink={this.handlePreviewLink} /></span>
           </div>
           <CodeMirror
             onScroll={this.handleScroll}

--- a/client/less/editor.less
+++ b/client/less/editor.less
@@ -216,3 +216,22 @@
 .cm-header-4 {
   font-size: 1.3em;
 }
+
+.fileRename {
+  display: inline-block;
+  color: #888;
+
+  .fileRename_display:hover{
+    cursor: pointer
+  }
+
+  .fileRename_buttons {
+    i {
+      padding-left: 5px;
+
+      &:hover {
+        cursor: pointer
+      }
+    }
+  }
+}

--- a/client/page.js
+++ b/client/page.js
@@ -97,9 +97,6 @@ var Page = React.createClass({
     if (!page || !settings) {
       return <span>Loading...</span>
     }
-    var url = window.location.href.replace(/^.*\/\/[^\/]+/, '').split('/')
-    var rootPath = url.slice(0, url.indexOf('admin')).join('/')
-    var permaLink = rootPath + '/' + page.path
     return Editor({
       isPage: true,
       post: this.state.page,
@@ -109,7 +106,6 @@ var Page = React.createClass({
       updated: this.state.updated,
       title: this.state.title,
       rendered: this.state.rendered,
-      previewLink: permaLink,
       onChange: this.handleChange,
       onChangeContent: this.handleChangeContent,
       onChangeTitle: this.handleChangeTitle,

--- a/client/post.js
+++ b/client/post.js
@@ -37,7 +37,6 @@ var Post = React.createClass({
   },
 
   handleChange: function (update) {
-    console.log('post.handleChange')
     var now = moment()
     api.post(this.props.params.postId, update).then((data) => {
       this.setState({

--- a/client/post.js
+++ b/client/post.js
@@ -1,5 +1,4 @@
 
-var path = require('path')
 var DataFetcher = require('./data-fetcher');
 var api = require('./api');
 var React = require('react/addons')
@@ -38,6 +37,7 @@ var Post = React.createClass({
   },
 
   handleChange: function (update) {
+    console.log('post.handleChange')
     var now = moment()
     api.post(this.props.params.postId, update).then((data) => {
       this.setState({
@@ -108,9 +108,6 @@ var Post = React.createClass({
     if (!post || !this.state.tagsAndCategories || !settings) {
       return <span>Loading...</span>
     }
-    var url = window.location.href.replace(/^.*\/\/[^\/]+/, '').split('/')
-    var rootPath = url.slice(0, url.indexOf('admin')).join('/')
-    var permaLink = path.join(rootPath, '/', post.path)
     return Editor({
       post: this.state.post,
       raw: this.state.initialRaw,
@@ -119,7 +116,6 @@ var Post = React.createClass({
       updated: this.state.updated,
       title: this.state.title,
       rendered: this.state.rendered,
-      previewLink: permaLink,
       onChange: this.handleChange,
       onChangeContent: this.handleChangeContent,
       onChangeTitle: this.handleChangeTitle,

--- a/client/rename-file.js
+++ b/client/rename-file.js
@@ -1,11 +1,13 @@
 
+var path = require('path')
 var React = require('react/addons')
 var PT = React.PropTypes
 var api = require('./api')
 
 var RenameFile = React.createClass({
   propTypes: {
-    post: PT.object
+    post: PT.object,
+    handlePreviewLink: PT.func
   },
 
   getInitialState: function() {
@@ -40,7 +42,13 @@ var RenameFile = React.createClass({
     var editingName = this.state.editingName
     api.renamePost(postId, editingName).then(result => {
       console.log(`successfully renamed file to ${editingName}`)
-      this.setState({filename: editingName, editing: false})
+
+      var url = window.location.pathname.split('/')
+      var rootPath = url.slice(0, url.indexOf('admin')).join('/')
+      var previewLink = path.join(rootPath, result.path)
+
+      this.setState({filename: editingName, editing: false},
+                    this.props.handlePreviewLink(previewLink))
     })
   },
 

--- a/client/rename-file.js
+++ b/client/rename-file.js
@@ -41,6 +41,11 @@ var RenameFile = React.createClass({
     var postId = this.props.post._id
     var editingName = this.state.editingName
     api.renamePost(postId, editingName).then(result => {
+      if (!result) {
+        console.log('error renaming file.')
+        this.toggleEditing()
+        return
+      }
       console.log(`successfully renamed file to ${editingName}`)
 
       var url = window.location.pathname.split('/')

--- a/client/rename-file.js
+++ b/client/rename-file.js
@@ -1,0 +1,73 @@
+
+var React = require('react/addons')
+var PT = React.PropTypes
+var api = require('./api')
+
+var RenameFile = React.createClass({
+  propTypes: {
+    post: PT.object
+  },
+
+  getInitialState: function() {
+    return {
+      filename: '',
+      editing: false,
+      editingName: ''
+    }
+  },
+
+  componentDidMount: function() {
+    var filename = this.props.post.source
+    this.setState({
+      filename: filename,
+      editingName: filename
+    })
+  },
+
+  toggleEditing: function() {
+    this.setState({
+      editing: !this.state.editing,
+      editingName: this.state.filename
+    })
+  },
+
+  handleEditChange: function(e) {
+    this.setState({editingName: e.target.value})
+  },
+
+  handleRenameFile: function(e) {
+    var postId = this.props.post._id
+    var editingName = this.state.editingName
+    api.renamePost(postId, editingName).then(result => {
+      console.log(`successfully renamed file to ${editingName}`)
+      this.setState({filename: editingName, editing: false})
+    })
+  },
+
+  render: function() {
+    return (
+      <div className='fileRename'>
+        {!this.state.editing &&
+          <div className='fileRename_display'
+            title='Click to rename'
+            onClick={this.toggleEditing}>
+            {this.state.filename}
+          </div>}
+        {this.state.editing && <span>
+          <input type='text'
+            onChange={this.handleEditChange}
+            defaultValue={this.state.editingName} />
+          <span className='fileRename_buttons'>
+            <i title='Cancel'
+              className='fa fa-times'
+              onClick={this.toggleEditing} />
+            <i title='Rename File'
+              className='fa fa-check'
+              onClick={this.handleRenameFile} />
+          </span></span>}
+      </div>
+    )
+  }
+})
+
+module.exports = RenameFile

--- a/client/rename-file.js
+++ b/client/rename-file.js
@@ -57,6 +57,16 @@ var RenameFile = React.createClass({
     })
   },
 
+  handleKeyPress: function(e) {
+    if (e.key === 'Enter') {
+      return this.handleRenameFile()
+    }
+    // esccape key
+    if (e.keyCode === 27) {
+      return this.toggleEditing()
+    }
+  },
+
   render: function() {
     return (
       <div className='fileRename'>
@@ -69,6 +79,7 @@ var RenameFile = React.createClass({
         {this.state.editing && <span>
           <input type='text'
             onChange={this.handleEditChange}
+            onKeyDown={this.handleKeyPress}
             defaultValue={this.state.editingName} />
           <span className='fileRename_buttons'>
             <i title='Cancel'

--- a/docs/demo/test-api.js
+++ b/docs/demo/test-api.js
@@ -69,6 +69,7 @@ module.exports = function (config) {
       ids[id].isDraft = true
       return Promise.resolve(ids[id])
     },
+    renamePost: (id, filename) => Promise.resolve({path: filename}),
     tagsAndCategories: () => Promise.resolve(config.tagsAndCategories),
     settings: () => Promise.resolve(config.settings),
     setSetting: (name, value, addedOptions) => {


### PR DESCRIPTION
The editor now displays the filename (and path). Clicking on it makes it editable.

The markdown files can be renamed and even moved into subfolders. The preview link updates accordingly.

![image](https://cloud.githubusercontent.com/assets/14897503/22187327/02709eb0-e0ca-11e6-824f-cd2b072c673d.png)

A new API endpoint was added, `posts/{postId}/rename`, that is used by both posts and pages.
