### PR TITLE
Minor CSS fixes

### DIFF
--- a/client/less/editor.less
+++ b/client/less/editor.less
@@ -3,6 +3,7 @@
   display: flex;
   flex: 1;
   flex-direction: column;
+  max-width: 100%
 }
 
 .editor_top {

--- a/www/css/screen.css
+++ b/www/css/screen.css
@@ -655,6 +655,10 @@ figure.highlight pre {
     margin: 0;
 }
 
+pre .line {
+  height: 20px
+}
+
 /* Theme: Solarized - Github
  * More theme here: http://softwaremaniacs.org/media/soft/highlight/test.html
  */


### PR DESCRIPTION
Fixes some CSS problems.

#95: empty code lines don't render properly; gave them a defined `height`
#107: editor width affected by long lines; gave it a `max-width`