### PR TITLE
authentication setup page

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,13 +47,9 @@ admin:
   secret: a secret something
 ```
 
-The `password_hash` is the bcrypt hash of your password. You can use [this
-site](https://www.bcrypt-generator.com/) to come up with that, or whatever you
-want. The `secret` is used to make the cookies secure, so it's a good idea to
-have it be long and complicated.
-
-Once that's in place, start up your hexo server and going to `/admin/` will
-require you to enter your password.
+A utility in Hexo admin's Settings can hash your password and generate the `admin`
+section for you. Start Hexo and go to Settings&nbsp;>&nbsp;Setup&nbsp;authentification
+and fill out your information. Copy the generated YAML into your `_config.yml`.
 
 ### 5. Contribute!
 - let me know how it can be improved in the [github

--- a/client/auth-setup.js
+++ b/client/auth-setup.js
@@ -1,0 +1,102 @@
+
+var React = require('react/addons')
+var bcrypt = require('bcrypt-nodejs')
+
+var AdminYaml = React.createClass({
+  getInitialState: function() {
+    return {
+      passwordHash: '$2a$10$L.XAIqIWgTc5S1zpvV3MEu7/rH34p4Is/nq824smv8EZ3lIPCp1su'
+    }
+  },
+
+  componentDidUpdate: function (prevProps) {
+    if (prevProps.password !== this.props.password) {
+      var salt = bcrypt.genSaltSync(10)
+      var hash = bcrypt.hashSync(this.props.password, salt)
+      this.setState({passwordHash: hash})
+    }
+  },
+
+  render: function() {
+
+    var adminYaml = [
+      '# hexo-admin authentification',
+      'admin:',
+      '  username: ' + this.props.username,
+      '  password_hash: ' + this.state.passwordHash,
+      '  secret: ' + this.props.secret
+    ].join('\n')
+    return (
+      <pre>
+        {adminYaml}
+      </pre>
+    )
+  }
+})
+
+var AuthSetup = React.createClass({
+  getInitialState: function() {
+    return {
+      username: 'username',
+      password: 'password',
+      secret: 'my super secret phrase'
+    }
+  },
+
+  handleUsernameChange: function(e) {
+    this.setState({username: e.target.value})
+  },
+
+  handlePasswordChange: function(e) {
+    this.setState({password: e.target.value})
+  },
+
+  handleSecretChange: function(e) {
+    this.setState({secret: e.target.value})
+  },
+
+  render: function() {
+    return (
+      <div className='authSetup'>
+        <h1>Authentification Setup</h1>
+        <p>
+          You can secure hexo-admin with a password by adding a section to your&nbsp;
+          <code>_config.yml</code>. This page is here to easily get it setup up.
+          Simply fill in the following fields and copy and paste the generated
+          text section into your config file.
+        </p>
+        <div>
+          <label>Username:</label>
+          <p>The username you'll use to log in.</p>
+          <input type='text'
+                 onChange={this.handleUsernameChange}
+                 defaultValue={this.state.username}></input>
+        </div>
+        <div>
+        <label>Password:</label>
+          <p>The password you'll use to log in. This will be encrypted to store in your config.</p>
+          <input type='text'
+                 onChange={this.handlePasswordChange}
+                 defaultValue={this.state.password}></input>
+        </div>
+        <div>
+        <label>Secret:</label>
+          <p>This is used to encrypt cookies; make it long and obscure.</p>
+          <input type='text'
+                 onChange={this.handleSecretChange}
+                 defaultValue={this.state.secret}></input>
+        </div>
+        <h2>Admin Config Section</h2>
+        <p>
+          Copy this into your <code>_config.yml</code>, and restart Hexo. Now you'll
+          be protected with a password!
+        </p>
+        <AdminYaml username={this.state.username}
+                   password={this.state.password}
+                   secret={this.state.secret}/>
+      </div>
+    );
+  }
+})
+
+module.exports = AuthSetup

--- a/client/less/auth-setup.less
+++ b/client/less/auth-setup.less
@@ -1,0 +1,21 @@
+
+.authSetup {
+  padding: 50px;
+  max-width: 100%;
+
+  h2 {
+    margin-top: 25px
+  }
+
+  p {
+    margin: 0
+  }
+
+  > div {
+    margin: 20px 0
+  }
+
+  label {
+    font-weight: 800
+  }
+}

--- a/client/less/index.less
+++ b/client/less/index.less
@@ -11,3 +11,4 @@
 @import "./about.less";
 @import "./deploy.less";
 @import "./settings.less";
+@import "./auth-setup.less";

--- a/client/router.js
+++ b/client/router.js
@@ -7,6 +7,7 @@ var Pages = require('./pages')
 var About = require('./about')
 var Deploy = require('./deploy')
 var Settings = require('./settings')
+var AuthSetup = require('./auth-setup')
 var Route = require('react-router').Route
 
 module.exports = () => {
@@ -18,5 +19,6 @@ module.exports = () => {
     <Route name="about" handler={About}/>
     <Route name="deploy" handler={Deploy}/>
     <Route name="settings" handler={Settings}/>
+    <Route name="auth-setup" handler={AuthSetup}/>
   </Route>
 }

--- a/client/settings.js
+++ b/client/settings.js
@@ -1,5 +1,6 @@
 
 var React = require('react/addons')
+var Link = require('react-router').Link
 var SettingsCheckbox = require('./settings-checkbox')
 var SettingsTextbox = require('./settings-textbox')
 
@@ -56,6 +57,10 @@ var Settings = React.createClass({
         <h1>Settings</h1>
         <p>
           Set various settings for your admin panel and editor.
+        </p>
+        <p>
+          Hexo admin can be secured with a password.
+          {' '}<Link to='auth-setup'>Setup authentification here.</Link>
         </p>
         <hr />
 


### PR DESCRIPTION
Adds a user-friendly utility that hopes to solve #103 by providing an alternative to the brcypt website listed in the Readme. It no longer generates password hashes recognized by `bcrypt-nodejs`. This allows the user to generate their `admin` config section for easy authentication setup.

It is linked to in the Settings, and looks like this:

![image](https://cloud.githubusercontent.com/assets/14897503/22216941/ae777caa-e166-11e6-9e27-4b17d4612cc2.png)
