### PR TITLE
Disable Remove Button For Published Posts

### DIFF
--- a/client/editor.js
+++ b/client/editor.js
@@ -81,11 +81,15 @@ var Editor = React.createClass({
           <button className="editor_unpublish" onClick={this.props.onUnpublish}>
             Unpublish
           </button>)}
-          {!this.props.isPage &&
+          {!this.props.isPage && (this.props.isDraft ?
           <button className="editor_remove" title="Remove"
                   onClick={this.props.onRemove}>
             <i className="fa fa-trash-o" aria-hidden="true"/>
-          </button>}
+          </button> :
+          <button className="editor_remove" title="Can't Remove Published Post"
+                  onClick={this.props.onRemove} disabled>
+            <i className="fa fa-trash-o" aria-hidden="true"/>
+          </button>)}
           {!this.props.isPage &&
           <button className="editor_checkGrammar" title="Check for Writing Improvements"
                   onClick={this.onCheckGrammar}>


### PR DESCRIPTION
When removing a published post, the post will stay in the blog and its just getting more complicated to remove it since the post is not present in the admin dashboard anymore.

This commit is only intended to prevent that scenario from happening at least until the right/better way is implemented.

Result: 
![out](https://cloud.githubusercontent.com/assets/13122042/23773535/49297b36-0552-11e7-82c1-e130b17ddecd.gif)

I've never used React before, so I wasn't very confident in altering more codes.
Thanks, would love to know a better way of doing this.