### PR TITLE
fix windows os deplay fail:deploy Error: spawn UNKNOWN

### DIFF
--- a/api.js
+++ b/api.js
@@ -410,8 +410,14 @@ module.exports = function (app, hexo) {
     if (!hexo.config.admin || !hexo.config.admin.deployCommand) {
       return res.done({error: 'Config value "admin.deployCommand" not found'});
     }
+
+    var deployCommand = hexo.config.admin.deployCommand;
+    if(process.platform === "win32"){
+      deployCommand =  hexo.config.admin.win32DeployCommand;
+    }
+
     try {
-      deploy(hexo.config.admin.deployCommand, req.body.message, function(err, result) {
+      deploy(deployCommand, req.body.message, function(err, result) {
         console.log('res', err, result);
         if (err) {
           return res.done({error: err.message || err})


### PR DESCRIPTION
在hexo服务主目录配置文件_config.yml的原有配置admin.win32DeployCommand: 'hexo-deploy.bat'

eq:

```ymal

admin:
  username: ...
  password_hash: ...
  secret: ...
  deployCommand: './hexo-deploy.sh'
  win32DeployCommand: 'hexo-deploy.bat'

```

并在在同级目录创建文件hexo-deploy.bat 去执行 hexo-deploy.sh脚本